### PR TITLE
add field for serviceName

### DIFF
--- a/api/v1beta1/teamcity_types.go
+++ b/api/v1beta1/teamcity_types.go
@@ -76,6 +76,10 @@ type NodeSpec struct {
 
 	Affinity v1.Affinity `json:"affinity,omitempty"`
 
+	// ServiceName is the name of the service that governs this StatefulSet.
+	// If empty, the StatefulSet spec.serviceName will not be set.
+	ServiceName string `json:"serviceName,omitempty"`
+
 	Responsibilities []string `json:"responsibilities,omitempty"`
 }
 

--- a/charts/teamcity-operator/templates/teamcity-crd.yaml
+++ b/charts/teamcity-operator/templates/teamcity-crd.yaml
@@ -3319,6 +3319,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      serviceName:
+                        description: |-
+                          ServiceName is the name of the service that governs this StatefulSet.
+                          If empty, the StatefulSet spec.serviceName will not be set.
+                        type: string
                       startupProbeSettings:
                         default:
                           failureThreshold: 15
@@ -6443,6 +6448,11 @@ spec:
                           items:
                             type: string
                           type: array
+                        serviceName:
+                          description: |-
+                            ServiceName is the name of the service that governs this StatefulSet.
+                            If empty, the StatefulSet spec.serviceName will not be set.
+                          type: string
                         startupProbeSettings:
                           default:
                             failureThreshold: 15

--- a/config/crd/bases/jetbrains.com_teamcities.yaml
+++ b/config/crd/bases/jetbrains.com_teamcities.yaml
@@ -3320,6 +3320,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      serviceName:
+                        description: |-
+                          ServiceName is the name of the service that governs this StatefulSet.
+                          If empty, the StatefulSet spec.serviceName will not be set.
+                        type: string
                       startupProbeSettings:
                         default:
                           failureThreshold: 15
@@ -6450,6 +6455,11 @@ spec:
                           items:
                             type: string
                           type: array
+                        serviceName:
+                          description: |-
+                            ServiceName is the name of the service that governs this StatefulSet.
+                            If empty, the StatefulSet spec.serviceName will not be set.
+                          type: string
                         startupProbeSettings:
                           default:
                             failureThreshold: 15

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_service.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_service.yaml
@@ -19,7 +19,7 @@ spec:
           requests:
             storage: 1Gi
   serviceList:
-    - name: tc-sample-svc
+    - name: tc-sample-one-svc
       spec:
         selector:
           app.kubernetes.io/name: teamcity-sample-with-svc
@@ -33,11 +33,20 @@ spec:
   mainNode:
     name: node
     spec:
+      serviceName: tc-sample-one-svc
       env:
         AWS_DEFAULT_REGION: "eu-west-1"
       requests:
         cpu: "400m"
         memory: "1000Mi"
+  secondaryNodes:
+    - name: secondary-node
+      spec:
+        serviceName: tc-sample-one-svc
+        requests:
+          cpu: "400m"
+          memory: "1000Mi"
+        responsibilities: ["CAN_PROCESS_BUILD_MESSAGES"]
   dataDirVolumeClaim:
     name: teamcity-node-volume1
     volumeMount:

--- a/internal/resource/secondarystatefulset_test.go
+++ b/internal/resource/secondarystatefulset_test.go
@@ -332,6 +332,38 @@ var _ = Describe("Secondary StatefulSet", func() {
 			}
 		})
 	})
+	Context("TeamCity with serviceName", func() {
+		BeforeEach(func() {
+			BeforeEachBuild(func(teamcity *TeamCity) {
+				teamcity.Spec.SecondaryNodes = getSecondaryNodes()
+				teamcity.Spec.SecondaryNodes[0].Spec.ServiceName = serviceNameSecondary + "-0"
+				teamcity.Spec.SecondaryNodes[1].Spec.ServiceName = serviceNameSecondary + "-1"
+			})
+		})
+		It("sets serviceName in StatefulSet spec", func() {
+			objectList, err := DefaultSecondaryStatefulSetBuilder.BuildObjectList()
+			Expect(err).NotTo(HaveOccurred())
+			for i, object := range objectList {
+				err = DefaultSecondaryStatefulSetBuilder.Update(object)
+				statefulSet := object.(*v1.StatefulSet)
+				Expect(statefulSet.Spec.ServiceName).To(Equal(Instance.Spec.SecondaryNodes[i].Spec.ServiceName))
+			}
+		})
+		It("allows multiple secondary nodes to use the same serviceName", func() {
+			objectList, err := DefaultSecondaryStatefulSetBuilder.BuildObjectList()
+			Expect(err).NotTo(HaveOccurred())
+
+			sharedServiceName := "shared-secondary-svc"
+			Instance.Spec.SecondaryNodes[0].Spec.ServiceName = sharedServiceName
+			Instance.Spec.SecondaryNodes[1].Spec.ServiceName = sharedServiceName
+
+			for _, object := range objectList {
+				err = DefaultSecondaryStatefulSetBuilder.Update(object)
+				statefulSet := object.(*v1.StatefulSet)
+				Expect(statefulSet.Spec.ServiceName).To(Equal(sharedServiceName))
+			}
+		})
+	})
 	Context("TeamCity with extra env variables", func() {
 		BeforeEach(func() {
 			BeforeEachBuild(func(teamcity *TeamCity) {

--- a/internal/resource/statefulset_utils.go
+++ b/internal/resource/statefulset_utils.go
@@ -196,6 +196,9 @@ func ConfigureStatefulSet(instance *TeamCity, node Node, current *v1.StatefulSet
 	current.Spec.Template.Spec.SecurityContext = &node.Spec.PodSecurityContext
 	current.Spec.Template.Spec.ServiceAccountName = instance.Spec.ServiceAccount.Name
 	current.Spec.Template.Spec.DeprecatedServiceAccount = ""
+	if node.Spec.ServiceName != "" {
+		current.Spec.ServiceName = node.Spec.ServiceName
+	}
 }
 
 func ConvertNodeEnvVars(env map[string]string) (envVars []v12.EnvVar) {


### PR DESCRIPTION
## Summary

This PR adds `serviceName` support to `NodeSpec` so the TeamCity operator can set
`spec.serviceName` on the StatefulSets it manages.

This is needed for headless-Service-backed StatefulSets, where Kubernetes pod DNS is derived from
the governing service:

    <pod-name>.<service-name>.<namespace>.svc.cluster.local

Without `spec.serviceName`, pod-specific DNS names do not resolve correctly, which breaks
DNS-based routing and discovery patterns for TeamCity nodes.

## Problem

The operator creates StatefulSets for TeamCity main and secondary nodes, but it did not expose any
way to set `spec.serviceName` from the TeamCity CR.

That means even if a user defines a headless Service in `serviceList`, the generated StatefulSets
still have an empty `spec.serviceName`. As a result:

- pod DNS entries are not created as expected
- DNS-based routing through a headless Service does not work
- users cannot reliably address specific TeamCity pods by stable hostname

This is especially important because `spec.serviceName` is immutable in Kubernetes. If a
StatefulSet is created without it, the only way to fix it is to recreate the StatefulSet.

## Change

A new optional field was added to `NodeSpec`:

```go
ServiceName string `json:"serviceName,omitempty"`
```

During StatefulSet generation, when this field is set on a node, the operator now propagates it to:
```
statefulSet.Spec.ServiceName
```

## Implementation Details

NodeSpec now exposes:
```go
// ServiceName is the name of the service that governs this StatefulSet.
// If empty, the StatefulSet spec.serviceName will not be set.
ServiceName string `json:"serviceName,omitempty"`
```
This keeps the field scoped per node, which matches how the operator already models main and secondary StatefulSets.

In the StatefulSet builder, the operator now sets:
```go
if node.Spec.ServiceName != "" {
    current.Spec.ServiceName = node.Spec.ServiceName
}
```
This is intentionally conditional so that existing CRs without the field remain unchanged.

## Compatibility
- Backward compatible
- Optional field only
- No change for existing TeamCity CRs unless serviceName is explicitly set
- No change to TeamCity deployment logic beyond passing through the StatefulSet field

## Validation
The change was verified by checking the current implementation path:
- NodeSpec includes serviceName
- StatefulSet configuration assigns spec.serviceName when provided
- generated deepcopy remains valid for the new string field

## Example Usage
```yaml 
spec:
  mainNode:
    name: main-node
    spec:
      serviceName: tc-sample

  secondaryNodes:
    - name: secondary-node
      spec:
        serviceName: tc-sample
```