### PR TITLE
Update TeamCity workflow and configuration for improved PR builds and…

### DIFF
--- a/.github/workflows/trigger-pr-build.yaml
+++ b/.github/workflows/trigger-pr-build.yaml
@@ -1,6 +1,18 @@
-name: Trigger TeamCity on /test
+name: Trigger TeamCity tests
+
+# Queues TeamCity Test&Build:
+#   - PRs (including forks): branch pull/<number>
+#   - pushes to main: branch main
+#   - manual /test comment on a PR (admins only)
+#
+# TeamCity must have the Pull Requests build feature enabled (see .teamcity/builds/TestBuild.kt).
 
 on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
   issue_comment:
     types: [created, edited]
 
@@ -11,27 +23,46 @@ jobs:
     permissions:
       pull-requests: read
       issues: write
-      contents: write
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test')
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request && contains(github.event.comment.body, '/test'))
     outputs:
       build_id: ${{ steps.trigger.outputs.build_id }}
       build_url: ${{ steps.trigger.outputs.build_url }}
     steps:
-      - name: Validate and get PR branch
-        id: pr
+      - name: Resolve TeamCity branch
+        id: branch
+        env:
+          TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.comment.user.login || github.actor }}
+          EVENT: ${{ github.event_name }}
+          PR_NUM_TARGET: ${{ github.event.pull_request.number }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
         run: |
-          TOKEN="${{ github.token }}"
-          REPO="${{ github.repository }}"
-          AUTHOR="${{ github.event.comment.user.login }}"
-          PR_NUM="${{ github.event.issue.number }}"
+          if [ "$EVENT" = "push" ]; then
+            TEAMCITY_BRANCH="main"
+            echo "Triggering TeamCity for push to main"
+          elif [ "$EVENT" = "pull_request_target" ]; then
+            PR_NUM="$PR_NUM_TARGET"
+            [ -n "$PR_NUM" ] || { echo "::error::Could not resolve pull request number"; exit 1; }
+            TEAMCITY_BRANCH="pull/$PR_NUM"
+            echo "Triggering TeamCity for PR #$PR_NUM (branch pull/$PR_NUM)"
+          else
+            PERM=$(curl -s -H "Authorization: Bearer $TOKEN" \
+              "https://api.github.com/repos/$REPO/collaborators/$AUTHOR/permission" | jq -r '.permission // empty')
+            [ "$PERM" = "admin" ] || {
+              echo "::error::Only repository admins can trigger /test. User '$AUTHOR' has permission: ${PERM:-none}."
+              exit 1
+            }
+            PR_NUM="$ISSUE_NUM"
+            [ -n "$PR_NUM" ] || { echo "::error::Could not resolve pull request number"; exit 1; }
+            TEAMCITY_BRANCH="pull/$PR_NUM"
+            echo "Triggering TeamCity for PR #$PR_NUM via /test (branch pull/$PR_NUM)"
+          fi
 
-          PERM=$(curl -s -H "Authorization: Bearer $TOKEN" "https://api.github.com/repos/$REPO/collaborators/$AUTHOR/permission" | jq -r '.permission // empty')
-          [ "$PERM" = "admin" ] || { echo "::error::Only repository owners can trigger this. User '$AUTHOR' has permission: ${PERM:-none}."; exit 1; }
-
-          BRANCH=$(curl -s -H "Authorization: Bearer $TOKEN" "https://api.github.com/repos/$REPO/pulls/$PR_NUM" | jq -r '.head.ref // empty')
-          [ -n "$BRANCH" ] || { echo "::error::Could not get PR head branch"; exit 1; }
-
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "teamcity_branch=$TEAMCITY_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Trigger TeamCity pipeline
         id: trigger
@@ -39,21 +70,40 @@ jobs:
           TEAMCITY_SERVER_URL: ${{ vars.TEAMCITY_SERVER_URL }}
           TEAMCITY_PIPELINE_ID: ${{ vars.TEAMCITY_PIPELINE_ID }}
           TEAMCITY_TOKEN: ${{ secrets.TEAMCITY_TOKEN }}
-          BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          BRANCH_NAME: ${{ steps.branch.outputs.teamcity_branch }}
         run: |
           [ -n "$TEAMCITY_SERVER_URL" ] && [ -n "$TEAMCITY_PIPELINE_ID" ] && [ -n "$TEAMCITY_TOKEN" ] || \
             { echo "::error::Set TEAMCITY_SERVER_URL, TEAMCITY_PIPELINE_ID (variables) and TEAMCITY_TOKEN (secret)."; exit 1; }
 
           BASE="${TEAMCITY_SERVER_URL%/}"
-          BODY=$(jq -n --arg id "$TEAMCITY_PIPELINE_ID" --arg branch "$BRANCH_NAME" '{ buildType: { id: $id }, branchName: $branch }')
+          BODY=$(jq -n --arg id "$TEAMCITY_PIPELINE_ID" --arg branch "$BRANCH_NAME" \
+            '{ buildType: { id: $id }, branchName: $branch }')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE/app/rest/buildQueue" \
-            -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $TEAMCITY_TOKEN" -d "$BODY")
+            -H "Content-Type: application/json" -H "Accept: application/json" \
+            -H "Authorization: Bearer $TEAMCITY_TOKEN" -d "$BODY")
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY_JSON=$(echo "$RESPONSE" | sed '$d')
 
-          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] || { echo "::error::TeamCity trigger failed (HTTP $HTTP_CODE)"; echo "$BODY_JSON"; exit 1; }
+          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] || {
+            echo "::error::TeamCity trigger failed (HTTP $HTTP_CODE)"
+            echo "$BODY_JSON"
+            exit 1
+          }
           BUILD_ID=$(echo "$BODY_JSON" | jq -r '.id // empty')
           [ -n "$BUILD_ID" ] || { echo "::error::Could not parse build id"; echo "$BODY_JSON"; exit 1; }
 
-          echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
-          echo "build_url=$BASE/viewLog.html?buildId=$BUILD_ID" >> $GITHUB_OUTPUT
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+          echo "build_url=$BASE/viewLog.html?buildId=$BUILD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Comment build link on manual /test
+        if: github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BUILD_URL: ${{ steps.trigger.outputs.build_url }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUM/comments" \
+            -d "$(jq -n --arg body "TeamCity build queued: $BUILD_URL" '{ body: $body }')"

--- a/.github/workflows/trigger-pr-build.yaml
+++ b/.github/workflows/trigger-pr-build.yaml
@@ -1,15 +1,11 @@
 name: Trigger TeamCity tests
 
-# Queues TeamCity Test&Build:
-#   - PRs (including forks): branch pull/<number>
-#   - pushes to main: branch main
-#   - manual /test comment on a PR (admins only)
+# Queues TeamCity Test&Build for pull requests (including forks) using branch pull/<number>.
+# Pushes to main are handled by the TeamCity VCS trigger on TestBuild — not this workflow.
 #
 # TeamCity must have the Pull Requests build feature enabled (see .teamcity/builds/TestBuild.kt).
 
 on:
-  push:
-    branches: [main]
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [main]
@@ -24,15 +20,14 @@ jobs:
       pull-requests: read
       issues: write
     if: |
-      github.event_name == 'push' ||
       github.event_name == 'pull_request_target' ||
       (github.event.issue.pull_request && contains(github.event.comment.body, '/test'))
     outputs:
       build_id: ${{ steps.trigger.outputs.build_id }}
       build_url: ${{ steps.trigger.outputs.build_url }}
     steps:
-      - name: Resolve TeamCity branch
-        id: branch
+      - name: Resolve PR number and TeamCity branch
+        id: pr
         env:
           TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -41,14 +36,8 @@ jobs:
           PR_NUM_TARGET: ${{ github.event.pull_request.number }}
           ISSUE_NUM: ${{ github.event.issue.number }}
         run: |
-          if [ "$EVENT" = "push" ]; then
-            TEAMCITY_BRANCH="main"
-            echo "Triggering TeamCity for push to main"
-          elif [ "$EVENT" = "pull_request_target" ]; then
+          if [ "$EVENT" = "pull_request_target" ]; then
             PR_NUM="$PR_NUM_TARGET"
-            [ -n "$PR_NUM" ] || { echo "::error::Could not resolve pull request number"; exit 1; }
-            TEAMCITY_BRANCH="pull/$PR_NUM"
-            echo "Triggering TeamCity for PR #$PR_NUM (branch pull/$PR_NUM)"
           else
             PERM=$(curl -s -H "Authorization: Bearer $TOKEN" \
               "https://api.github.com/repos/$REPO/collaborators/$AUTHOR/permission" | jq -r '.permission // empty')
@@ -57,12 +46,13 @@ jobs:
               exit 1
             }
             PR_NUM="$ISSUE_NUM"
-            [ -n "$PR_NUM" ] || { echo "::error::Could not resolve pull request number"; exit 1; }
-            TEAMCITY_BRANCH="pull/$PR_NUM"
-            echo "Triggering TeamCity for PR #$PR_NUM via /test (branch pull/$PR_NUM)"
           fi
 
-          echo "teamcity_branch=$TEAMCITY_BRANCH" >> "$GITHUB_OUTPUT"
+          [ -n "$PR_NUM" ] || { echo "::error::Could not resolve pull request number"; exit 1; }
+
+          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "teamcity_branch=pull/$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "Triggering TeamCity for PR #$PR_NUM (branch pull/$PR_NUM)"
 
       - name: Trigger TeamCity pipeline
         id: trigger
@@ -70,7 +60,7 @@ jobs:
           TEAMCITY_SERVER_URL: ${{ vars.TEAMCITY_SERVER_URL }}
           TEAMCITY_PIPELINE_ID: ${{ vars.TEAMCITY_PIPELINE_ID }}
           TEAMCITY_TOKEN: ${{ secrets.TEAMCITY_TOKEN }}
-          BRANCH_NAME: ${{ steps.branch.outputs.teamcity_branch }}
+          BRANCH_NAME: ${{ steps.pr.outputs.teamcity_branch }}
         run: |
           [ -n "$TEAMCITY_SERVER_URL" ] && [ -n "$TEAMCITY_PIPELINE_ID" ] && [ -n "$TEAMCITY_TOKEN" ] || \
             { echo "::error::Set TEAMCITY_SERVER_URL, TEAMCITY_PIPELINE_ID (variables) and TEAMCITY_TOKEN (secret)."; exit 1; }

--- a/.teamcity/builds/TestBuild.kt
+++ b/.teamcity/builds/TestBuild.kt
@@ -1,13 +1,11 @@
 package builds
 
 import _Self.vcsRoots.TeamCityOperatorVCSRoot
-import consts.dockerHubRegistryConnectionId
-import environment.EnvironmentProvider
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
 import jetbrains.buildServer.configs.kotlin.buildFeatures.perfmon
-import jetbrains.buildServer.configs.kotlin.buildFeatures.sshAgent
+import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.triggers.vcs
 import util.BuildSteps
@@ -18,6 +16,10 @@ object TestBuild : BuildType({
 
     vcs {
         root(TeamCityOperatorVCSRoot)
+        branchFilter = """
+            +:refs/pull/*
+            +:refs/heads/main
+        """.trimIndent()
     }
 
     steps {
@@ -35,6 +37,8 @@ object TestBuild : BuildType({
     }
 
     triggers {
+        // Builds are queued by GitHub Actions (push to main, pull_request_target, /test)
+        // via REST API. VCS trigger stays off to avoid duplicate runs.
         vcs {
             branchFilter = """
                 -:*
@@ -44,6 +48,14 @@ object TestBuild : BuildType({
 
     features {
         perfmon {}
+        pullRequests {
+            vcsRootExtId = TeamCityOperatorVCSRoot.id?.toString()
+            provider = github {
+                authType = vcsRoot()
+                filterTargetBranch = "+:refs/heads/main"
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+            }
+        }
         commitStatusPublisher {
             vcsRootExtId = TeamCityOperatorVCSRoot.id?.toString()
             publisher = github {

--- a/.teamcity/builds/TestBuild.kt
+++ b/.teamcity/builds/TestBuild.kt
@@ -37,11 +37,11 @@ object TestBuild : BuildType({
     }
 
     triggers {
-        // Builds are queued by GitHub Actions (push to main, pull_request_target, /test)
-        // via REST API. VCS trigger stays off to avoid duplicate runs.
+        // main: VCS trigger on push (commit status published by commitStatusPublisher).
+        // PRs (incl. forks): queued by GitHub Actions via pull/<number> — see trigger-pr-build.yaml.
         vcs {
             branchFilter = """
-                -:*
+                +:refs/heads/main
             """.trimIndent()
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
+ENVTEST_VERSION ?= release-0.19
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -211,7 +212,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
… manual triggers

- Extend GitHub Actions workflow to handle `push`, `pull_request_target`, and `/test` commands for TeamCity builds.
- Add PR build support in `.teamcity` configuration with the `pullRequests` feature enabled for GitHub integrations.
- Update Makefile to parameterize `envtest` version.