### PR TITLE
support user-provided env variables via []EnvVar

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,13 @@ spec:
     name: main-node
     spec:
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: access-key-id
       requests:
         cpu: "900m"
         memory: "1512Mi"
@@ -595,7 +601,6 @@ When defining `spec.serviceList` selectors, use the standard labels the operator
 ## Limitations
 
 - Custom volume mounts are not available; this feature is under development.
-- Mounting custom Secrets as environment variables is currently not supported.
 - Ingress integration has been tested with the NGINX Ingress Controller only.
 
 ## Contributing

--- a/api/v1beta1/teamcity_types.go
+++ b/api/v1beta1/teamcity_types.go
@@ -59,10 +59,10 @@ type TeamCitySpec struct {
 }
 
 type NodeSpec struct {
-	InitContainers []v1.Container    `json:"initContainers,omitempty"`
-	Requests       v1.ResourceList   `json:"requests"` // mandatory, since we rely on it with Xmx setup
-	Env            map[string]string `json:"env,omitempty"`
-	Limits         v1.ResourceList   `json:"limits,omitempty"`
+	InitContainers []v1.Container  `json:"initContainers,omitempty"`
+	Requests       v1.ResourceList `json:"requests"` // mandatory, since we rely on it with Xmx setup
+	Env            []v1.EnvVar     `json:"env,omitempty"`
+	Limits         v1.ResourceList `json:"limits,omitempty"`
 	// +kubebuilder:default:={runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000}
 	PodSecurityContext v1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// +kubebuilder:default:={failureThreshold: 3, successThreshold: 1, periodSeconds: 20, initialDelaySeconds: 60, timeoutSeconds: 1}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -129,9 +129,9 @@ func (in *NodeSpec) DeepCopyInto(out *NodeSpec) {
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Limits != nil {

--- a/charts/teamcity-operator/templates/teamcity-crd.yaml
+++ b/charts/teamcity-operator/templates/teamcity-crd.yaml
@@ -1469,9 +1469,118 @@ spec:
                             type: object
                         type: object
                       env:
-                        additionalProperties:
-                          type: string
-                        type: object
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       initContainers:
                         items:
                           description: A single application container that you want
@@ -3754,7 +3863,7 @@ spec:
                 type: array
               readinessEndpoint:
                 default:
-                  path: /healthCheck/ready
+                  path: /healthCheck/healthy
                   port: 8111
                   scheme: HTTP
                 description: HTTPGetAction describes an action based on HTTP Get requests.
@@ -4590,9 +4699,118 @@ spec:
                               type: object
                           type: object
                         env:
-                          additionalProperties:
-                            type: string
-                          type: object
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         initContainers:
                           items:
                             description: A single application container that you want

--- a/config/crd/bases/jetbrains.com_teamcities.yaml
+++ b/config/crd/bases/jetbrains.com_teamcities.yaml
@@ -1462,9 +1462,118 @@ spec:
                             type: object
                         type: object
                       env:
-                        additionalProperties:
-                          type: string
-                        type: object
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       initContainers:
                         items:
                           description: A single application container that you want
@@ -4594,9 +4703,118 @@ spec:
                               type: object
                           type: object
                         env:
-                          additionalProperties:
-                            type: string
-                          type: object
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
                         initContainers:
                           items:
                             description: A single application container that you want

--- a/config/samples/teamcity_full.yaml
+++ b/config/samples/teamcity_full.yaml
@@ -113,7 +113,18 @@ spec:
           command: [ 'sh', '-c', "echo Hello" ]
       responsibilities: [ "MAIN_NODE", "CAN_PROCESS_USER_DATA_MODIFICATION_REQUESTS" ]
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: access-key-id
+        - name: FEATURE_FLAGS
+          valueFrom:
+            configMapKeyRef:
+              name: teamcity-feature-flags
+              key: flags
       podSecurityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_database.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_database.yaml
@@ -85,7 +85,8 @@ spec:
     name: main-node
     spec:
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
       requests:
         cpu: "900m"
         memory: "1512Mi"

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_ingress.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_ingress.yaml
@@ -19,7 +19,8 @@ spec:
     name: main-node
     spec:
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
       requests:
         cpu: "900m"
         memory: "1512Mi"

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_init_containers.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_init_containers.yaml
@@ -22,7 +22,8 @@ spec:
           image: busybox:1.28
           command: [ 'sh', '-c', "echo Hello" ]
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
       requests:
         cpu: "900m"
         memory: "1512Mi"

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_node_selector.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_node_selector.yaml
@@ -18,7 +18,8 @@ spec:
    name: main-node
    spec:
     env:
-      AWS_DEFAULT_REGION: "eu-west-1"
+      - name: AWS_DEFAULT_REGION
+        value: "eu-west-1"
     requests:
       cpu: "1000m"
       memory: "2500Mi"

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_service.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_service.yaml
@@ -46,7 +46,8 @@ spec:
     spec:
       serviceName: tc-sample-one-svc
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
       requests:
         cpu: "400m"
         memory: "1000Mi"

--- a/config/samples/v1beta1/_v1beta1_teamcity_with_serviceaccount.yaml
+++ b/config/samples/v1beta1/_v1beta1_teamcity_with_serviceaccount.yaml
@@ -22,7 +22,8 @@ spec:
     name: node
     spec:
       env:
-        AWS_DEFAULT_REGION: "eu-west-1"
+        - name: AWS_DEFAULT_REGION
+          value: "eu-west-1"
       requests:
         cpu: "400m"
         memory: "1000Mi"

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -60,6 +60,38 @@ Important notes:
 - TeamCity Server logs are not copied. They are stored separately from the Data Directory.
 
 
+## Breaking changes
+
+### `spec.mainNode.spec.env` / `spec.secondaryNodes[*].spec.env` — type change
+
+The `env` field on `NodeSpec` is now a list of Kubernetes [`EnvVar`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core) entries instead of a `map[string]string`. This enables sourcing values from `ConfigMap` and `Secret` objects via `valueFrom`.
+
+Update your existing TeamCity custom resources before applying the new CRD:
+
+```yaml
+# Before
+mainNode:
+  spec:
+    env:
+      AWS_DEFAULT_REGION: "eu-west-1"
+      AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
+
+# After
+mainNode:
+  spec:
+    env:
+      - name: AWS_DEFAULT_REGION
+        value: "eu-west-1"
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: aws-credentials
+            key: access-key-id
+```
+
+Apply the updated custom resources together with the new CRD; otherwise the API server will reject the manifests.
+
+
 ## Tips and references
 - Responsibilities and multi-node concepts: https://www.jetbrains.com/help/teamcity/multinode-setup.html
 - TeamCity Data Directory: https://www.jetbrains.com/help/teamcity/teamcity-data-directory.html

--- a/internal/resource/secondarystatefulset_test.go
+++ b/internal/resource/secondarystatefulset_test.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
@@ -373,21 +372,19 @@ var _ = Describe("Secondary StatefulSet", func() {
 				teamcity.Spec.SecondaryNodes[1].Spec.Env = getExtraNodeEnvVars()
 			})
 		})
-		It("sets node env variables correctly", func() {
+		It("sets node env variables correctly (literal values and valueFrom)", func() {
 			objectList, err := DefaultSecondaryStatefulSetBuilder.BuildObjectList()
 			Expect(err).NotTo(HaveOccurred())
 			for i, object := range objectList {
 				err = DefaultSecondaryStatefulSetBuilder.Update(object)
+				Expect(err).NotTo(HaveOccurred())
 				statefulSet := object.(*v1.StatefulSet)
 				env := statefulSet.Spec.Template.Spec.Containers[0].Env
 
-				expectedEnvVariables := Instance.Spec.SecondaryNodes[i].Spec.Env
-				expectedEnvVariablesKeys := reflect.ValueOf(expectedEnvVariables).MapKeys()
-
-				for _, key := range expectedEnvVariablesKeys {
-					envVarIndex := slices.IndexFunc(env, func(c v12.EnvVar) bool { return c.Name == key.String() })
-					envVarValue := env[envVarIndex].Value
-					Expect(envVarValue).To(Equal(expectedEnvVariables[key.String()]))
+				for _, expected := range Instance.Spec.SecondaryNodes[i].Spec.Env {
+					idx := slices.IndexFunc(env, func(c v12.EnvVar) bool { return c.Name == expected.Name })
+					Expect(idx).To(BeNumerically(">=", 0), "env variable %q should be present", expected.Name)
+					Expect(env[idx]).To(Equal(expected))
 				}
 			}
 		})

--- a/internal/resource/statefulset_test.go
+++ b/internal/resource/statefulset_test.go
@@ -11,7 +11,6 @@ import (
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"reflect"
 	"strings"
 )
 
@@ -421,7 +420,7 @@ var _ = Describe("StatefulSet", func() {
 				teamcity.Spec.MainNode.Spec.Env = getExtraNodeEnvVars()
 			})
 		})
-		It("sets node env variables correctly", func() {
+		It("sets node env variables correctly (literal values and valueFrom)", func() {
 			obj, err := DefaultStatefulSetBuilder.BuildObjectList()
 			Expect(err).NotTo(HaveOccurred())
 			stsObject := obj[0]
@@ -430,15 +429,11 @@ var _ = Describe("StatefulSet", func() {
 			statefulSet := stsObject.(*v1.StatefulSet)
 			env := statefulSet.Spec.Template.Spec.Containers[0].Env
 
-			expectedEnvVariables := Instance.Spec.MainNode.Spec.Env
-			expectedEnvVariablesKeys := reflect.ValueOf(expectedEnvVariables).MapKeys()
-
-			for _, key := range expectedEnvVariablesKeys {
-				envVarIndex := slices.IndexFunc(env, func(c v12.EnvVar) bool { return c.Name == key.String() })
-				envVarValue := env[envVarIndex].Value
-				Expect(envVarValue).To(Equal(expectedEnvVariables[key.String()]))
+			for _, expected := range Instance.Spec.MainNode.Spec.Env {
+				idx := slices.IndexFunc(env, func(c v12.EnvVar) bool { return c.Name == expected.Name })
+				Expect(idx).To(BeNumerically(">=", 0), "env variable %q should be present", expected.Name)
+				Expect(env[idx]).To(Equal(expected))
 			}
-
 		})
 	})
 

--- a/internal/resource/statefulset_utils.go
+++ b/internal/resource/statefulset_utils.go
@@ -201,18 +201,6 @@ func ConfigureStatefulSet(instance *TeamCity, node Node, current *v1.StatefulSet
 	}
 }
 
-func ConvertNodeEnvVars(env map[string]string) (envVars []v12.EnvVar) {
-	for k, v := range env {
-		var envVar = v12.EnvVar{
-			Name:      k,
-			Value:     v,
-			ValueFrom: nil,
-		}
-		envVars = append(envVars, envVar)
-	}
-	return envVars
-}
-
 func DatabaseEnvVarBuilder(databaseSecretName string) []v12.EnvVar {
 	return []v12.EnvVar{
 		{
@@ -255,8 +243,7 @@ func BuildEnvVariablesFromGlobalAndNodeSpecificSettings(instance *TeamCity, node
 	extraServerOpts = responsibilities + extraServerOpts
 	xmxValue := XmxValueCalculator(instance.Spec.XmxPercentage, node.Spec.Requests.Memory().Value())
 	envVars := DefaultEnvironmentVariableBuilder(node.Name, xmxValue, dataDirPath, extraServerOpts)
-	nodeSpecificEnvVars := ConvertNodeEnvVars(node.Spec.Env)
-	envVars = append(envVars, nodeSpecificEnvVars...)
+	envVars = append(envVars, node.Spec.Env...)
 	if instance.DatabaseSecretProvided() {
 		databaseEnvVars := DatabaseEnvVarBuilder(instance.Spec.DatabaseSecret.Secret)
 		envVars = append(envVars, databaseEnvVars...)

--- a/internal/resource/testutils.go
+++ b/internal/resource/testutils.go
@@ -335,9 +335,33 @@ func getServiceAccount() ServiceAccount {
 	}
 }
 
-func getExtraNodeEnvVars() map[string]string {
-	return map[string]string{
-		"AWS_DEFAULT_REGION": "eu-west-1",
-		"HELLO":              "WORLD",
+func getExtraNodeEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "AWS_DEFAULT_REGION",
+			Value: "eu-west-1",
+		},
+		{
+			Name:  "HELLO",
+			Value: "WORLD",
+		},
+		{
+			Name: "AWS_ACCESS_KEY_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "aws-creds"},
+					Key:                  "access-key-id",
+				},
+			},
+		},
+		{
+			Name: "FEATURE_FLAGS",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "tc-config"},
+					Key:                  "feature-flags",
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
Replace map[string]string with []corev1.EnvVar in NodeSpec.Env so users can source values from Secrets and ConfigMaps via valueFrom. This is a breaking change to v1beta1 CRD — existing custom resources using the map form must be updated (see docs/MIGRATION.md)